### PR TITLE
Cached canvas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/StefanBossbaly/rustic-pixel-display"
 authors = ["Stefan Bossbaly <sbossb@gmail.com>"]
 license = "GPL"
 
-
 [dependencies]
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7.8"
@@ -31,7 +30,7 @@ rustic_pixel_display = { path = "rustic-pixel-display", features = ["http_server
 rustic_pixel_display_macros = { path = "rustic-pixel-display/macros" }
 home-assistant-rest = "0.2.0"
 septa-api = "0.3.4"
-amtrak-api = { git = "https://github.com/StefanBossbaly/amtrak-api.git", branch = "master" }
+amtrak-api = "0.1.0"
 geoutils = "0.5.1"
 clap = { version= "4.4", features = ["derive"] }
 serde_json = "1.0.105"
@@ -52,3 +51,8 @@ name = "rpi"
 
 [[bin]]
 name = "rpi_http"
+
+[profile.release]
+debug = 1
+[rust]
+debuginfo-level = 1

--- a/rustic-pixel-display/src/render/cached_canvas.rs
+++ b/rustic-pixel-display/src/render/cached_canvas.rs
@@ -80,7 +80,7 @@ where
         let pixels = self
             .pixels
             .clone()
-            .into_iter()
+            .iter()
             .enumerate()
             .map(|(offset, color)| Pixel(self.convert_offset_to_point(offset).unwrap(), *color))
             .collect::<Vec<_>>();

--- a/rustic-pixel-display/src/render/cached_canvas.rs
+++ b/rustic-pixel-display/src/render/cached_canvas.rs
@@ -1,0 +1,92 @@
+use std::convert::Infallible;
+
+use embedded_graphics::{
+    pixelcolor::Rgb888,
+    prelude::{DrawTarget, OriginDimensions, Point, RgbColor, Size},
+    Pixel,
+};
+
+use super::Render;
+
+#[derive(Debug)]
+pub struct CachedCanvas {
+    size: Size,
+    pixels: Box<[Rgb888]>,
+}
+
+impl CachedCanvas {
+    pub fn new(size: Size) -> CachedCanvas {
+        let num_of_pixels = size.width as usize * size.height as usize;
+
+        Self {
+            size,
+            pixels: vec![Rgb888::BLACK; num_of_pixels].into_boxed_slice(),
+        }
+    }
+
+    fn convert_point_to_offset(&self, point: Point) -> Option<usize> {
+        let (x, y) = (point.x as u32, point.y as u32);
+        if x < self.size.width && y < self.size.height {
+            Some((x + y * self.size.width) as usize)
+        } else {
+            None
+        }
+    }
+
+    fn convert_offset_to_point(&self, offset: usize) -> Option<Point> {
+        let x = offset as u32 % self.size.width;
+        let y = offset as u32 / self.size.width;
+
+        if x < self.size.width && y < self.size.height {
+            Some(Point {
+                x: x as i32,
+                y: y as i32,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl OriginDimensions for CachedCanvas {
+    fn size(&self) -> Size {
+        self.size
+    }
+}
+
+impl DrawTarget for CachedCanvas {
+    type Color = Rgb888;
+    type Error = Infallible;
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = embedded_graphics::Pixel<Self::Color>>,
+    {
+        for Pixel(point, color) in pixels.into_iter() {
+            if let Some(index) = self.convert_point_to_offset(point) {
+                self.pixels[index] = color;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<D> Render<D> for CachedCanvas
+where
+    D: DrawTarget<Color = Rgb888, Error = Infallible>,
+{
+    fn render(&self, canvas: &mut D) -> Result<(), D::Error> {
+        let pixels = self
+            .pixels
+            .clone()
+            .into_iter()
+            .enumerate()
+            .map(|(offset, color)| Pixel(self.convert_offset_to_point(offset).unwrap(), *color))
+            .collect::<Vec<_>>();
+
+        canvas.draw_iter(pixels)?;
+
+        Ok(())
+    }
+}

--- a/rustic-pixel-display/src/render/mod.rs
+++ b/rustic-pixel-display/src/render/mod.rs
@@ -2,8 +2,10 @@ use anyhow::Result;
 use embedded_graphics::{pixelcolor::Rgb888, prelude::DrawTarget};
 use std::{convert::Infallible, io::Read};
 
+mod cached_canvas;
 mod sub_canvas;
 
+pub use cached_canvas::CachedCanvas;
 pub use sub_canvas::SubCanvas;
 
 pub trait Render<D>

--- a/src/bin/rpi_http.rs
+++ b/src/bin/rpi_http.rs
@@ -14,7 +14,9 @@ use rustic_pixel_examples::renders::{
 use std::{convert::Infallible, sync::Arc, vec};
 
 #[derive(RenderFactories)]
-enum RenderFactoryEntries<D: DrawTarget<Color = Rgb888, Error = Infallible>> {
+enum RenderFactoryEntries<
+    D: DrawTarget<Color = Rgb888, Error = Infallible> + Clone + Send + 'static,
+> {
     TransitTracker(TransitTrackerFactory<D>),
     UpcomingArrivals(UpcomingArrivalsFactory<D>),
     Weather(WeatherFactory<D>),
@@ -51,7 +53,7 @@ async fn main() -> Result<()> {
             interlaced: false,
             dither_bits: 0,
             chain_length: 2,
-            parallel: 1,
+            parallel: 2,
             panel_type: None,
             multiplexing: None,
             row_setter: RowAddressSetterType::Direct,

--- a/src/bin/rpi_http.rs
+++ b/src/bin/rpi_http.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
-use embedded_graphics::{pixelcolor::Rgb888, prelude::DrawTarget};
+use embedded_graphics::{
+    pixelcolor::Rgb888,
+    prelude::{DrawTarget, OriginDimensions},
+};
 use parking_lot::Mutex;
 use rustic_pixel_display::{
     config::{HardwareConfig, HardwareMapping, LedSequence, RowAddressSetterType},
@@ -14,9 +17,7 @@ use rustic_pixel_examples::renders::{
 use std::{convert::Infallible, sync::Arc, vec};
 
 #[derive(RenderFactories)]
-enum RenderFactoryEntries<
-    D: DrawTarget<Color = Rgb888, Error = Infallible> + Clone + Send + 'static,
-> {
+enum RenderFactoryEntries<D: DrawTarget<Color = Rgb888, Error = Infallible> + OriginDimensions> {
     TransitTracker(TransitTrackerFactory<D>),
     UpcomingArrivals(UpcomingArrivalsFactory<D>),
     Weather(WeatherFactory<D>),

--- a/src/bin/simulator_http.rs
+++ b/src/bin/simulator_http.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use embedded_graphics::{
     pixelcolor::Rgb888,
-    prelude::{DrawTarget, Point, RgbColor, Size},
+    prelude::{DrawTarget, OriginDimensions, Point, RgbColor, Size},
     primitives::Rectangle,
 };
 use embedded_graphics_simulator::{
@@ -30,9 +30,7 @@ const DISPLAY_SIZE: Size = Size {
 };
 
 #[derive(RenderFactories)]
-enum RenderFactoryEntries<
-    D: DrawTarget<Color = Rgb888, Error = Infallible> + Send + Clone + 'static,
-> {
+enum RenderFactoryEntries<D: DrawTarget<Color = Rgb888, Error = Infallible> + OriginDimensions> {
     TransitTracker(TransitTrackerFactory<D>),
     UpcomingArrivals(UpcomingArrivalsFactory<D>),
     Weather(WeatherFactory<D>),

--- a/src/bin/simulator_http.rs
+++ b/src/bin/simulator_http.rs
@@ -30,7 +30,9 @@ const DISPLAY_SIZE: Size = Size {
 };
 
 #[derive(RenderFactories)]
-enum RenderFactoryEntries<D: DrawTarget<Color = Rgb888, Error = Infallible>> {
+enum RenderFactoryEntries<
+    D: DrawTarget<Color = Rgb888, Error = Infallible> + Send + Clone + 'static,
+> {
     TransitTracker(TransitTrackerFactory<D>),
     UpcomingArrivals(UpcomingArrivalsFactory<D>),
     Weather(WeatherFactory<D>),


### PR DESCRIPTION
Create the first version of the cached_canvas struct. This struct acts
as both a canvas and a render. It allows us to only draw when new data
is available. This is perfect for renders that infrequently update the
canvas (TransitBoard) and pull down data on a fixed cadance.